### PR TITLE
Filter triggers by application

### DIFF
--- a/src/AdsPlayer.ts
+++ b/src/AdsPlayer.ts
@@ -79,10 +79,11 @@ export class AdsPlayer {
     * @param {HTMLMediaElement} video - the main video player
     * @param {HTMLElement} adsPlayerContainer - the HTML element that will contains ad media element
     * @param {boolean} handleMainPlayerPlayback - true (by default) if AdsPlayer shall handle the main video playback state
+    * @param {Function} filterTriggersFn - the callback function for filtering triggers
     */
-    init (video: HTMLMediaElement, adsPlayerContainer: HTMLElement, handleMainPlayerPlayback: boolean = true) {
+    init (video: HTMLMediaElement, adsPlayerContainer: HTMLElement, handleMainPlayerPlayback: boolean = true, filterTriggersFn?: Function) {
         this.adsPlayerController = new AdsPlayerController(this.eventBus);
-        this.adsPlayerController.init(video, adsPlayerContainer, handleMainPlayerPlayback);
+        this.adsPlayerController.init(video, adsPlayerContainer, handleMainPlayerPlayback, filterTriggersFn);
         this.eventBus.addEventListener(EventTypes.ERROR, this.onErrorListener);
     }
 

--- a/src/AdsPlayer.ts
+++ b/src/AdsPlayer.ts
@@ -79,7 +79,7 @@ export class AdsPlayer {
     * @param {HTMLMediaElement} video - the main video player
     * @param {HTMLElement} adsPlayerContainer - the HTML element that will contains ad media element
     * @param {boolean} handleMainPlayerPlayback - true (by default) if AdsPlayer shall handle the main video playback state
-    * @param {Function} filterTriggersFn - the callback function for filtering triggers
+    * @param {Function} filterTriggersFn - the callback function to filter triggers
     */
     init (video: HTMLMediaElement, adsPlayerContainer: HTMLElement, handleMainPlayerPlayback: boolean = true, filterTriggersFn?: Function) {
         this.adsPlayerController = new AdsPlayerController(this.eventBus);

--- a/src/lib/AdsPlayerController.ts
+++ b/src/lib/AdsPlayerController.ts
@@ -110,7 +110,7 @@ export class AdsPlayerController {
      * @param {Object} video - the HTML5 video element used by the main media player
      * @param {Object} adsPlayerContainer - The container to create the HTML5 video/image elements used to play and render the ads media
      * @param {boolean} handleMainPlayerPlayback - true (by default) if AdsPlayer shall handle the main video playback state
-     * @param {Function} filterTriggersFn - the callback function for filtering triggers
+     * @param {Function} filterTriggersFn - the callback function to filter triggers
      */
     init (video: HTMLMediaElement, adsPlayerContainer: HTMLElement, handleMainPlayerPlayback: boolean = false, filterTriggersFn?: Function) {
         this.mainVideo = video;


### PR DESCRIPTION
This PR enables application to filter triggers once the MAST is loaded.
This allows the application for example to remove triggers according to their type (pre-roll, mid-roll...)